### PR TITLE
Update SecureStringHelper.cs

### DIFF
--- a/source/CoreSharp/Utilities/SecureStringHelper.cs
+++ b/source/CoreSharp/Utilities/SecureStringHelper.cs
@@ -6,26 +6,25 @@ namespace AndreasReitberger.Core.Utilities
 {
     public static class SecureStringHelper
     {
-        public static string ConvertToString(SecureString secureString)
+#nullable enable
+        public static string ConvertToString(SecureString? secureString)
         {
+            if (secureString == null) return string.Empty;
             IntPtr valuePtr = IntPtr.Zero;
             try
             {
                 valuePtr = Marshal.SecureStringToGlobalAllocUnicode(secureString);
-                return Marshal.PtrToStringUni(valuePtr);
+                return Marshal.PtrToStringUni(valuePtr) ?? string.Empty;
             }
             finally
             {
                 Marshal.ZeroFreeGlobalAllocUnicode(valuePtr);
             }
         }
-
-        public static SecureString ConvertToSecureString(string clearText)
+        public static SecureString ConvertToSecureString(string? clearText)
         {
-            if (clearText == null)
-                throw new ArgumentNullException(nameof(clearText));
-
-            var securePassword = new SecureString();
+            clearText ??= string.Empty;
+            SecureString securePassword = new();
 
             foreach (var c in clearText)
                 securePassword.AppendChar(c);
@@ -33,5 +32,6 @@ namespace AndreasReitberger.Core.Utilities
             securePassword.MakeReadOnly();
             return securePassword;
         }
+#nullable disable
     }
 }


### PR DESCRIPTION
Handled if the passed parameter is `null`.

Fixed #2